### PR TITLE
Allow dud host and dead host prune for transferred hosts

### DIFF
--- a/registry-index-service/package-lock.json
+++ b/registry-index-service/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "evernode-js-client": "0.6.9",
+                "evernode-js-client": "0.6.10",
                 "fs": "0.0.1-security",
                 "jsonwebtoken": "8.5.1"
             },
@@ -703,9 +703,9 @@
             }
         },
         "node_modules/evernode-js-client": {
-            "version": "0.6.9",
-            "resolved": "https://registry.npmjs.org/evernode-js-client/-/evernode-js-client-0.6.9.tgz",
-            "integrity": "sha512-EDjRR5B6Xi35k5WZ1RQUb/0f+UCLzL8Kxf39iGldp5pUlEisG42K+MYUa4LwOpNDMY6JLQiz38eJVnH1tnILUw==",
+            "version": "0.6.10",
+            "resolved": "https://registry.npmjs.org/evernode-js-client/-/evernode-js-client-0.6.10.tgz",
+            "integrity": "sha512-U12r56TN5YUtKhbR/oUQNqf4kzNA5kWfOjc1sC6AhCz+fRXJQ742N94+j//3Ekw/5ZPUI9AFsz0iAgDGF0YHdw==",
             "hasInstallScript": true,
             "dependencies": {
                 "elliptic": "6.5.4",
@@ -2485,9 +2485,9 @@
             "dev": true
         },
         "evernode-js-client": {
-            "version": "0.6.9",
-            "resolved": "https://registry.npmjs.org/evernode-js-client/-/evernode-js-client-0.6.9.tgz",
-            "integrity": "sha512-EDjRR5B6Xi35k5WZ1RQUb/0f+UCLzL8Kxf39iGldp5pUlEisG42K+MYUa4LwOpNDMY6JLQiz38eJVnH1tnILUw==",
+            "version": "0.6.10",
+            "resolved": "https://registry.npmjs.org/evernode-js-client/-/evernode-js-client-0.6.10.tgz",
+            "integrity": "sha512-U12r56TN5YUtKhbR/oUQNqf4kzNA5kWfOjc1sC6AhCz+fRXJQ742N94+j//3Ekw/5ZPUI9AFsz0iAgDGF0YHdw==",
             "requires": {
                 "elliptic": "6.5.4",
                 "libsodium-wrappers": "0.7.10",

--- a/registry-index-service/package.json
+++ b/registry-index-service/package.json
@@ -17,7 +17,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "evernode-js-client": "0.6.9",
+        "evernode-js-client": "0.6.10",
         "jsonwebtoken": "8.5.1",
         "fs": "0.0.1-security"
     },

--- a/utils/account-setup/package-lock.json
+++ b/utils/account-setup/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "evernode-js-client": "0.6.9"
+        "evernode-js-client": "0.6.10"
       },
       "devDependencies": {
         "eslint": "8.3.0"
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/evernode-js-client": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/evernode-js-client/-/evernode-js-client-0.6.9.tgz",
-      "integrity": "sha512-EDjRR5B6Xi35k5WZ1RQUb/0f+UCLzL8Kxf39iGldp5pUlEisG42K+MYUa4LwOpNDMY6JLQiz38eJVnH1tnILUw==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/evernode-js-client/-/evernode-js-client-0.6.10.tgz",
+      "integrity": "sha512-U12r56TN5YUtKhbR/oUQNqf4kzNA5kWfOjc1sC6AhCz+fRXJQ742N94+j//3Ekw/5ZPUI9AFsz0iAgDGF0YHdw==",
       "hasInstallScript": true,
       "dependencies": {
         "elliptic": "6.5.4",
@@ -2728,9 +2728,9 @@
       "dev": true
     },
     "evernode-js-client": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/evernode-js-client/-/evernode-js-client-0.6.9.tgz",
-      "integrity": "sha512-EDjRR5B6Xi35k5WZ1RQUb/0f+UCLzL8Kxf39iGldp5pUlEisG42K+MYUa4LwOpNDMY6JLQiz38eJVnH1tnILUw==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/evernode-js-client/-/evernode-js-client-0.6.10.tgz",
+      "integrity": "sha512-U12r56TN5YUtKhbR/oUQNqf4kzNA5kWfOjc1sC6AhCz+fRXJQ742N94+j//3Ekw/5ZPUI9AFsz0iAgDGF0YHdw==",
       "requires": {
         "elliptic": "6.5.4",
         "libsodium-wrappers": "0.7.10",

--- a/utils/account-setup/package.json
+++ b/utils/account-setup/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "evernode-js-client": "0.6.9"
+    "evernode-js-client": "0.6.10"
   },
   "devDependencies": {
     "eslint": "8.3.0"


### PR DESCRIPTION
- Allow transferred hosts to be pruned and removed from dud host removal
- Skip the reg token ownership if the host is transferred and not reinstalled